### PR TITLE
Photo comment authorization

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -76,8 +76,9 @@ class CommentsController < ApplicationController
         redirect_back fallback_location: root_url, alert: "Not authorized"
       end
     elsif action_name == 'create'
+      @photo = Photo.find(params.fetch(:comment).fetch(:photo_id))
       if current_user != @photo.owner && @photo.owner.private? && !current_user.leaders.include?(@photo.owner)
-        @photo = Photo.find(params.fetch(:comment).fetch(:photo_id))
+        redirect_back fallback_location: root_url, alert: "Not authorized"
       end
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[ show edit update destroy ]
-  before_action :is_an_authorized_user, only: [:destroy, :create]
+  before_action :is_an_authorized_user, only: [:destroy, :create, :edit]
 
   # GET /comments or /comments.json
   def index
@@ -71,7 +71,7 @@ class CommentsController < ApplicationController
     end
 
   def is_an_authorized_user
-    if action_name == 'destroy'
+    if action_name == 'destroy' || action_name == 'edit'
       if current_user != @comment.author
         redirect_back fallback_location: root_url, alert: "Not authorized"
       end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[ show edit update destroy ]
+  before_action :is_an_authorized_user, only: [:destroy, :create]
 
   # GET /comments or /comments.json
   def index
@@ -23,6 +24,7 @@ class CommentsController < ApplicationController
   def create
     @comment = Comment.new(comment_params)
     @comment.author = current_user
+
 
     respond_to do |format|
       if @comment.save
@@ -67,4 +69,16 @@ class CommentsController < ApplicationController
     def comment_params
       params.require(:comment).permit(:author_id, :photo_id, :body)
     end
+
+  def is_an_authorized_user
+    if action_name == 'destroy'
+      if current_user != @comment.author
+        redirect_back fallback_location: root_url, alert: "Not authorized"
+      end
+    elsif action_name == 'create'
+      if current_user != @photo.owner && @photo.owner.private? && !current_user.leaders.include?(@photo.owner)
+        @photo = Photo.find(params.fetch(:comment).fetch(:photo_id))
+      end
+    end
+  end
 end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,5 +1,7 @@
 class PhotosController < ApplicationController
   before_action :set_photo, only: %i[ show edit update destroy ]
+  before_action :ensure_current_user_is_owner, only: [:destroy, :update, :edit]
+
 
   # GET /photos or /photos.json
   def index
@@ -50,21 +52,35 @@ class PhotosController < ApplicationController
 
   # DELETE /photos/1 or /photos/1.json
   def destroy
-    @photo.destroy
-    respond_to do |format|
-      format.html { redirect_back fallback_location: root_url, notice: "Photo was successfully destroyed." }
-      format.json { head :no_content }
+
+    if current_user == @photo.owner
+      @photo.destroy
+
+      respond_to do |format|
+        format.html { redirect_back fallback_location: root_url, notice: "Photo was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    else
+      redirect_back(fallback_location: root_url, notice: "Nice try, but that is not your photo.")
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_photo
-      @photo = Photo.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def photo_params
-      params.require(:photo).permit(:image, :comments_count, :likes_count, :caption, :owner_id)
+  # Use callbacks to share common setup or constraints between actions.
+  def set_photo
+    @photo = Photo.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def photo_params
+    params.require(:photo).permit(:image, :comments_count, :likes_count, :caption, :owner_id)
+  end
+
+  def ensure_current_user_is_owner
+    if current_user != @photo.owner
+      redirect_back fallback_location: root_url, alert: "You're not authorized for that."
     end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,9 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[ show liked feed followers following discover ]
+  before_action :is_an_authorized_user, only: [:feed, :discover]
+
 
   private
-
     def set_user
       if params[:username]
         @user = User.find_by!(username: params.fetch(:username))
@@ -10,4 +11,13 @@ class UsersController < ApplicationController
         @user = current_user
       end
     end
+
+  def is_an_authorized_user
+    if params[:username]
+      @user = User.find_by!(username: params.fetch(:username))
+      if current_user != @user
+        redirect_back fallback_location: root_url, alert: "You're not authorized for that."
+      end
+    end
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,6 +22,7 @@
 class Comment < ApplicationRecord
   belongs_to :author, class_name: "User", counter_cache: true
   belongs_to :photo, counter_cache: true
+  has_one :owner, through: :photo
 
   validates :body, presence: true
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,14 +9,16 @@
       </h5>
       <p><%= comment.body %></p>
     </div>
-    <div>
-      <%= link_to edit_comment_path(comment), class: "btn btn-link btn-sm text-muted" do %>
-        <i class="fas fa-edit fa-fw"></i>
-      <% end %>
+    <% if current_user == comment.author %>
+      <div>
+        <%= link_to edit_comment_path(comment), class: "btn btn-link btn-sm text-muted" do %>
+          <i class="fas fa-edit fa-fw"></i>
+        <% end %>
 
-      <%= link_to comment, data: { turbo_method: :delete }, class: "btn btn-link btn-sm text-muted" do %>
-        <i class="fas fa-trash fa-fw"></i>
-      <% end %>
-    </div>
+        <%= link_to comment, data: { turbo_method: :delete }, class: "btn btn-link btn-sm text-muted" do %>
+          <i class="fas fa-trash fa-fw"></i>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </li>

--- a/app/views/photos/_photo.html.erb
+++ b/app/views/photos/_photo.html.erb
@@ -7,18 +7,20 @@
     </h2>
 
     <div>
-      <%= link_to edit_photo_path(photo), class: "btn btn-link btn-sm text-muted" do %>
-        <i class="fas fa-edit fa-fw"></i>
-      <% end %>
+      <% if current_user == photo.owner %>
+        <%= link_to edit_photo_path(photo), class: "btn btn-link btn-sm text-muted" do %>
+          <i class="fas fa-edit fa-fw"></i>
+        <% end %>
 
-      <%= link_to photo, data: { turbo_method: :delete }, class: "btn btn-link btn-sm text-muted" do %>
-        <i class="fas fa-trash fa-fw"></i>
+        <%= link_to photo, data: { turbo_method: :delete }, class: "btn btn-link btn-sm text-muted" do %>
+          <i class="fas fa-trash fa-fw"></i>
+        <% end %>
       <% end %>
     </div>
   </div>
 
   <%= image_tag photo.image, class: "img-fluid" %>
-  
+
   <div class="card-body">
     <p class="card-text"><%= photo.caption %></p>
   </div>
@@ -28,7 +30,7 @@
       <%= render "comments/comment", comment: comment %>
     <% end %>
   </ul>
-  
+
   <div class="card-body">
     <%= render "comments/form", comment: photo.comments.build %>
   </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -49,22 +49,24 @@
         <% end %>
       </div>
 
-      <div class="col">
-        <%=
-          link_to "#",
-            data: { 
-              bs_toggle: "modal", 
-              bs_target: "##{dom_id(user)}_pending"
-            } do %>
+      <% if current_user == user %>
+        <div class="col">
+          <%=
+            link_to "#",
+                    data: {
+                      bs_toggle: "modal",
+                      bs_target: "##{dom_id(user)}_pending"
+                    } do %>
 
           <span class="font-weight-bold">
             <%= user.pending.size %>
           </span>
-          
-          pending
 
-        <% end %>
-      </div>
+            pending
+
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
     <div class="row mb-3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,16 +4,19 @@
   </div>
 </div>
 
-<div class="row mb-2">
-  <div class="col-md-6 offset-md-3">
-    <%= render "users/profile_nav", user: @user %>
-  </div>
-</div>
-
-<% @user.own_photos.each do |photo| %>
-  <div class="row mb-4">
+<% if current_user == @user || !@user.private? || current_user.leaders.include?(@user) %>
+  <div class="row mb-2">
     <div class="col-md-6 offset-md-3">
-      <%= render "photos/photo", photo: photo %>
+      <%= render "users/profile_nav", user: @user %>
     </div>
   </div>
+
+  <% @user.own_photos.each do |photo| %>
+    <div class="row mb-4">
+      <div class="col-md-6 offset-md-3">
+        <%= render "photos/photo", photo: photo %>
+      </div>
+    </div>
+  <% end %>
 <% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ Rails.application.routes.draw do
   devise_for :users
   
   resources :comments
-  resources :follow_requests
-  resources :likes
-  resources :photos
+  resources :follow_requests, except: [:index, :show, :new, :edit]
+  resources :likes, only: [:create, :destroy]
+  resources :photos, except: [:index]
 
   get ":username" => "users#show", as: :user
   get ":username/liked" => "users#liked", as: :liked


### PR DESCRIPTION
Updated features:
- If user try to delete or edit a photo/comment that’s not user's, redirect them back and hide the link.
- user can visit any user’s profile and see followers/following, but posts and likes are visible only if:
The profile is not private.
- The profile is private, and user is an accepted follower.
- Only users can see their own pending follow requests.
- Feed and discover pages (/user/feed, /user/discover) are only viewable by that user.